### PR TITLE
Label threads to help with crash report analyzing

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Provides a thread for performing cache triage on a queue of requests.
@@ -54,6 +55,8 @@ public class CacheDispatcher extends Thread {
     /** Manage list of waiting requests and de-duplicate requests with same cache key. */
     private final WaitingRequestManager mWaitingRequestManager;
 
+    private static final AtomicInteger instanceCounter = new AtomicInteger();
+
     /**
      * Creates a new cache triage dispatcher thread. You must call {@link #start()} in order to
      * begin processing.
@@ -68,6 +71,8 @@ public class CacheDispatcher extends Thread {
             BlockingQueue<Request<?>> networkQueue,
             Cache cache,
             ResponseDelivery delivery) {
+        super("VolleyCache-" + instanceCounter.getAndIncrement());
+
         mCacheQueue = cacheQueue;
         mNetworkQueue = networkQueue;
         mCache = cache;

--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -23,6 +23,7 @@ import android.os.Process;
 import android.os.SystemClock;
 import androidx.annotation.VisibleForTesting;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Provides a thread for performing network dispatch from a queue of requests.
@@ -45,6 +46,8 @@ public class NetworkDispatcher extends Thread {
     /** Used for telling us to die. */
     private volatile boolean mQuit = false;
 
+    private static final AtomicInteger instanceCounter = new AtomicInteger();
+
     /**
      * Creates a new network dispatcher thread. You must call {@link #start()} in order to begin
      * processing.
@@ -59,6 +62,8 @@ public class NetworkDispatcher extends Thread {
             Network network,
             Cache cache,
             ResponseDelivery delivery) {
+        super("VolleyNetwork-" + instanceCounter.getAndIncrement());
+
         mQueue = queue;
         mNetwork = network;
         mCache = cache;


### PR DESCRIPTION
It's time consuming to open unnamed threads just to verify what they are